### PR TITLE
Use "parents" charts controller

### DIFF
--- a/app/controllers/api/charts_controller.rb
+++ b/app/controllers/api/charts_controller.rb
@@ -14,6 +14,24 @@ module Api
       render json: { labels: labels, data: data }
     end
 
+    def goal_action_type_teams
+      labels = add_filters_to_query(Team.left_joins(:home_games, :away_games, players: :goals)).all.pluck(:acronym).uniq
+      labels2 = add_filters_to_query(Goal.with_joins).all.pluck(:action_type).uniq
+      grouped_result = add_filters_to_query(Goal.with_joins).group("teams.acronym", "goals.action_type").count
+
+      data = unlink_labels(grouped_result, labels, labels2)
+      render json: { labels: labels, data: data}
+    end
+
+    def goal_action_type_matchweeks
+      labels = add_filters_to_query(Game.left_joins(:home_team, :away_team, :goals)).all.pluck(:matchweek).uniq
+      labels2 = add_filters_to_query(Goal.with_joins).all.pluck(:action_type).uniq
+      grouped_result = add_filters_to_query(Goal.with_joins).group("games.matchweek", "goals.action_type").count
+
+      data = unlink_labels(grouped_result, labels, labels2)
+      render json: { labels: labels, data: data}
+    end
+
     private
 
     def add_filters_to_query(query)
@@ -30,6 +48,18 @@ module Api
       end
 
       query
+    end
+
+    def unlink_labels(data, labels, labels2)
+      result = {}
+      labels2.each do |label2|
+        label_array = []
+        labels.each do |label|
+          label_array << (data[[label, label2]] || 0)
+        end
+        result[label2] = label_array
+      end
+      result
     end
   end
 end

--- a/app/controllers/api/charts_controller.rb
+++ b/app/controllers/api/charts_controller.rb
@@ -20,7 +20,7 @@ module Api
       grouped_result = add_filters_to_query(Goal.with_joins).group("teams.acronym", "goals.action_type").count
 
       data = unlink_labels(grouped_result, labels, labels2)
-      render json: { labels: labels, data: data}
+      render json: { labels: labels, data: data }
     end
 
     def goal_action_type_matchweeks
@@ -29,7 +29,7 @@ module Api
       grouped_result = add_filters_to_query(Goal.with_joins).group("games.matchweek", "goals.action_type").count
 
       data = unlink_labels(grouped_result, labels, labels2)
-      render json: { labels: labels, data: data}
+      render json: { labels: labels, data: data }
     end
 
     private

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,10 +1,5 @@
 class TeamsController < ApplicationController
   def index
-    games = Game.all.pluck(:matchweek).uniq
-    action_types = Goal.all.pluck(:action_type).uniq
-    teams = Team.all.pluck(:acronym).uniq
-    @chart1 = build_chart_data(labels: games, attributes: action_types, type: "goals_action_matchweek")
-    @chart2 = build_chart_data(labels: teams, attributes: action_types, type: "goals_action_team")
     @cards_data = build_cards_data
   end
 
@@ -16,38 +11,5 @@ class TeamsController < ApplicationController
       best_attack: Goal.joins(scorer: :team).group("teams.acronym").order("count_id desc").count(:id).first,
       best_scorer: Goal.joins(:scorer).group("players.name").order("count_id desc").count(:id).first,
     }
-  end
-
-  def build_chart_data(labels:, attributes:, type:)
-    chart_data = {labels: labels, attributes: attributes, data: nil}
-    chart_data[:data] = []
-
-    if type == "goals_action_matchweek"
-      query_results = Goal.joins(:game).group("games.matchweek", "goals.action_type").count
-    elsif type == "goals_action_team"
-      query_results = Goal.joins(scorer: :team).group("teams.acronym", "goals.action_type").count
-    end
-
-    if ["goals_action_matchweek", "goals_action_team"].include? type
-      formatted_response = transform_query_group(query_results)
-
-      attributes.each do |attribute|
-        attribute_arr = []
-        labels.each do |label|
-          attribute_arr << (formatted_response.dig(label, attribute) || 0)
-        end
-        chart_data[:data] << attribute_arr
-      end
-    end
-    chart_data
-  end
-
-  def transform_query_group(results)
-    formatted_result = {}
-    results.each do |(key, key2), quantity|
-      formatted_result[key] ||= {}
-      formatted_result[key][key2] = quantity
-    end
-    formatted_result
   end
 end

--- a/app/javascript/controllers/chart2d_controller.js
+++ b/app/javascript/controllers/chart2d_controller.js
@@ -57,14 +57,6 @@ export default class extends Controller {
     return JSON.parse(this.dataTarget.dataset.value)
   }
 
-  colorArray(color, count) {
-    var bgColors = [];
-    for (var i = 0; i < count; i++) {
-      bgColors.push(color);
-    }
-    return bgColors
-  }
-
   get colors(){
     return ["rgba(255, 99, 132, 0.5)",
       "rgba(255, 159, 64, 0.5)",

--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -7,18 +7,16 @@ export default class extends Controller {
 
   connect(){
     document.addEventListener("updateCharts", this.refreshChart.bind(this))
-    this.initChart()
-    this.refreshChart()
   }
 
   disconnect(){
     document.removeEventListener("updateCharts", this.refreshChart.bind(this))
   }
 
-  initChart() {
+  initChart(chartType) {
     var ctx = document.getElementById(this.data.get("canvasId")).getContext('2d');
     this.chart = new Chart(ctx, {
-      type: this.data.get("chartType"),
+      type: chartType,
       data: {},
       options: {
         scales: {
@@ -35,9 +33,9 @@ export default class extends Controller {
   refreshChart() {
     var team = document.querySelector("#filters").filters.teamTarget.value
     var action_type = document.querySelector("#filters").filters.actionTypeTarget.value
-    var matchweek =document.querySelector("#filters").filters.matchweekTarget.value
+    var matchweek = document.querySelector("#filters").filters.matchweekTarget.value
 
-    fetch(`api/${this.type}?team=${team}&action_type=${action_type}&matchweek=${matchweek}`)
+    fetch(`${this.apiUrl}?team=${team}&action_type=${action_type}&matchweek=${matchweek}`)
     .then(response => response.json())
     .then(chartData => {
       this.chart.config.data = this.refreshChartData(chartData)
@@ -58,10 +56,6 @@ export default class extends Controller {
         borderWidth: 1
       }]
     }
-  }
-
-  get type(){
-    return this.data.get("dataset")
   }
 
   get colors(){

--- a/app/javascript/controllers/charts/action_type_goals_controller.js
+++ b/app/javascript/controllers/charts/action_type_goals_controller.js
@@ -1,0 +1,17 @@
+import  ChartController from "../chart_controller.js"
+export default class extends ChartController {
+
+  connect(){
+    super.connect()
+    this.initChart(this.chartType)
+    this.refreshChart()
+  }
+
+  get apiUrl(){
+    return "/api/action_type_goals"
+  }
+
+  get chartType(){
+    return "polarArea"
+  }
+}

--- a/app/javascript/controllers/charts/team_goals_controller.js
+++ b/app/javascript/controllers/charts/team_goals_controller.js
@@ -1,0 +1,17 @@
+import  ChartController from "../chart_controller.js"
+export default class extends ChartController {
+
+  connect(){
+    super.connect()
+    this.initChart(this.chartType)
+    this.refreshChart()
+  }
+
+  get apiUrl(){
+    return "/api/team_goals"
+  }
+
+  get chartType(){
+    return "polarArea"
+  }
+}

--- a/app/javascript/controllers/multi_charts/goal_action_type_matchweeks_controller.js
+++ b/app/javascript/controllers/multi_charts/goal_action_type_matchweeks_controller.js
@@ -1,0 +1,17 @@
+import  MultiChartController from "../multi_chart_controller.js"
+export default class extends MultiChartController {
+
+  connect(){
+    super.connect()
+    this.initChart(this.chartType)
+    this.refreshChart()
+  }
+
+  get apiUrl(){
+    return "/api/goal_action_type_matchweeks"
+  }
+
+  get chartType(){
+    return "bar"
+  }
+}

--- a/app/javascript/controllers/multi_charts/goal_action_type_teams_controller.js
+++ b/app/javascript/controllers/multi_charts/goal_action_type_teams_controller.js
@@ -1,0 +1,17 @@
+import  MultiChartController from "../multi_chart_controller.js"
+export default class extends MultiChartController {
+
+  connect(){
+    super.connect()
+    this.initChart(this.chartType)
+    this.refreshChart()
+  }
+
+  get apiUrl(){
+    return "/api/goal_action_type_teams"
+  }
+
+  get chartType(){
+    return "bar"
+  }
+}

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -206,10 +206,7 @@
           </div>
           <div class="p-5">
             <canvas id="chart1"></canvas>
-            <div data-controller="chart2d" data-chart2d-canvas-id="chart1" data-chart2d-chart-type="bar">
-              <div class="hidden" data-target="chart2d.labels" data-value="<%= @chart1[:labels] %>"></div>
-              <div class="hidden" data-target="chart2d.datasetLabels" data-value="<%= @chart1[:attributes] %>"></div>
-              <div class="hidden" data-target="chart2d.data" data-value="<%= @chart1[:data] %>"></div>
+            <div data-controller="multi-charts--goal-action-type-matchweeks" data-multi-charts--goal-action-type-matchweeks-canvas-id="chart1">
             </div>
           </div>
         </div>
@@ -224,10 +221,7 @@
           </div>
           <div class="p-5">
             <canvas id="chart2"></canvas>
-            <div data-controller="chart2d" data-chart2d-canvas-id="chart2" data-chart2d-chart-type="bar">
-              <div class="hidden" data-target="chart2d.labels" data-value="<%= @chart2[:labels] %>"></div>
-              <div class="hidden" data-target="chart2d.datasetLabels" data-value="<%= @chart2[:attributes] %>"></div>
-              <div class="hidden" data-target="chart2d.data" data-value="<%= @chart2[:data] %>"></div>
+            <div data-controller="multi-charts--goal-action-type-teams" data-multi-charts--goal-action-type-teams-canvas-id="chart2">
             </div>
           </div>
         </div>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -242,7 +242,7 @@
           </div>
           <div class="p-5">
             <canvas id="pie-chart1"></canvas>
-            <div data-controller="chart" data-chart-dataset="action_type_goals" data-chart-canvas-id="pie-chart1" data-chart-chart-type="polarArea">
+            <div data-controller="charts--action-type-goals" data-charts--action-type-goals-canvas-id="pie-chart1">
             </div>
           </div>
         </div>
@@ -257,7 +257,7 @@
           </div>
           <div class="p-5">
             <canvas id="pie-chart2"></canvas>
-            <div data-controller="chart" data-chart-dataset="team_goals" data-chart-canvas-id="pie-chart2" data-chart-chart-type="polarArea">
+            <div data-controller="charts--team-goals" data-charts--team-goals-canvas-id="pie-chart2">
             </div>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
   namespace :api do
     get "/action_type_goals", to: "charts#action_type_goals"
     get "/team_goals", to: "charts#team_goals"
+    get "/goal_action_type_teams", to: "charts#goal_action_type_teams"
+    get "/goal_action_type_matchweeks", to: "charts#goal_action_type_matchweeks"
     get "/teams", to: "teams#index"
     get "/goals/action_types", to: "goals#action_types"
     get "/games/matchweeks", to: "games#matchweeks"

--- a/spec/controllers/api/charts_controller_spec.rb
+++ b/spec/controllers/api/charts_controller_spec.rb
@@ -27,4 +27,34 @@ describe Api::ChartsController do
       expect(parsed_body["data"]).to eq("ZZ" => 1)
     end
   end
+
+  describe "#goal_action_type_teams" do
+    it "returns labels and data as hash of arrays" do
+      team1 = create(:team, acronym: "ZZ")
+      team2 = create(:team, acronym: "team2")
+      player = create(:player, team: team1)
+      create(:goal, action_type: "Nice", scorer: player, game: create(:game, home_team: team1, away_team: team2))
+
+      get(:goal_action_type_teams)
+
+      parsed_body = JSON.parse(response.body)
+      expect(parsed_body["labels"]).to eq(["ZZ", "team2"])
+      expect(parsed_body["data"]).to eq("Nice" => [1, 0])
+    end
+  end
+
+  describe "#goal_action_type_matchweeks" do
+    it "returns labels and data as hash of arrays" do
+      team1 = create(:team, acronym: "ZZ")
+      team2 = create(:team, acronym: "team2")
+      player = create(:player, team: team1)
+      create(:goal, action_type: "Nice", scorer: player, game: create(:game, matchweek: "Day1", home_team: team1, away_team: team2))
+
+      get(:goal_action_type_matchweeks)
+
+      parsed_body = JSON.parse(response.body)
+      expect(parsed_body["labels"]).to eq(["Day1"])
+      expect(parsed_body["data"]).to eq("Nice" => [1])
+    end
+  end
 end


### PR DESCRIPTION
Chart2D becomes MultiChart.

There are now two main controllers : `Chart` and `MultiChart`
Each graph will have his own controller, in `/charts` or `/multi_charts` and will extend the associated controller.

All the event (like filter update) gonna be done in those parents controller from now on.

Also cleaned away the old cold in teams, much cleaner now. 
`api/charts` starts to be messy and mix behavior, maybe we should have two ends: charts and multi charts, like for controllers (would make sense)

Closes #30 
Closes #20
