### PR TITLE
Adding a player filter

### DIFF
--- a/app/controllers/api/charts_controller.rb
+++ b/app/controllers/api/charts_controller.rb
@@ -24,8 +24,8 @@ module Api
     end
 
     def goal_action_type_match_weeks
-      labels = add_filters_to_query(Game.left_joins(:teams, :goals)).pluck(:match_week).uniq
-      labels2 = add_filters_to_query(Goal.with_joins).pluck(:action_type).uniq
+      labels = add_filters_to_query(Game.joins(:goals, teams: :players)).all.pluck(:match_week).uniq
+      labels2 = add_filters_to_query(Goal.with_joins).all.pluck(:action_type).uniq
       grouped_result = add_filters_to_query(Goal.with_joins).group("games.match_week", "goals.action_type").count
 
       data = unlink_labels(grouped_result, labels, labels2)
@@ -47,6 +47,9 @@ module Api
         query = query.where(games: { match_week: match_week })
       end
 
+      if (player = params[:player].presence)
+        query = query.where(players: { name: player })
+      end
       query
     end
 

--- a/app/controllers/api/players_controller.rb
+++ b/app/controllers/api/players_controller.rb
@@ -1,0 +1,8 @@
+module Api
+  class PlayersController < ApplicationController
+    def index
+      players = Player.all
+      render json: players
+    end
+  end
+end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -1,0 +1,15 @@
+class PlayersController < ApplicationController
+  def index
+    @cards_data = build_cards_data
+  end
+
+  private
+
+  def build_cards_data
+    {
+      games_count: Game.count,
+      best_attack: Goal.joins(scorer: :team).group("teams.acronym").order("count_id desc").count(:id).first,
+      best_scorer: Goal.joins(:scorer).group("players.name").order("count_id desc").count(:id).first,
+    }
+  end
+end

--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -29,8 +29,8 @@ export default class extends Controller {
     var team = document.querySelector("#filters").filters.teamTarget.value
     var action_type = document.querySelector("#filters").filters.actionTypeTarget.value
     var match_week = document.querySelector("#filters").filters.matchWeekTarget.value
-
-    fetch(`${this.apiUrl}?team=${team}&action_type=${action_type}&match_week=${match_week}`)
+    var player = document.querySelector("#filters").filters.playerTarget.value
+    fetch(`${this.apiUrl}?team=${team}&player=${player}&action_type=${action_type}&match_week=${match_week}`)
     .then(response => response.json())
     .then(chartData => {
       this.chart.config.data = this.refreshChartData(chartData)

--- a/app/javascript/controllers/filters_controller.js
+++ b/app/javascript/controllers/filters_controller.js
@@ -1,11 +1,12 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = [ "team", "actionType", "matchWeek" ]
+  static targets = [ "team", "player", "actionType", "matchWeek" ]
 
   connect(){
     this.element[this.identifier] = this
     this.initTeamFilter()
+    this.initPlayerFilter()
     this.initActionTypeFilter()
     this.initMatchWeekFilter()
   }
@@ -24,6 +25,18 @@ export default class extends Controller {
         options = options + this.optionTemplate(team.acronym, team.name);
       });
       this.teamTarget.innerHTML = options;
+    });
+  }
+
+  initPlayerFilter(){
+    var options = `<option value="">Tous</option>`
+    fetch(`api/players`)
+    .then(response => response.json())
+    .then( players => {
+      players.forEach((player) => {
+        options = options + this.optionTemplate(player.name, player.name);
+      });
+      this.playerTarget.innerHTML = options;
     });
   }
 

--- a/app/javascript/controllers/multi_chart_controller.js
+++ b/app/javascript/controllers/multi_chart_controller.js
@@ -33,9 +33,10 @@ export default class extends Controller {
   refreshChart() {
     var team = document.querySelector("#filters").filters.teamTarget.value
     var action_type = document.querySelector("#filters").filters.actionTypeTarget.value
-    var matchWeek = document.querySelector("#filters").filters.matchWeekTarget.value
+    var match_week = document.querySelector("#filters").filters.matchWeekTarget.value
+    var player = document.querySelector("#filters").filters.playerTarget.value
 
-    fetch(`${this.apiUrl}?team=${team}&action_type=${action_type}&match_week=${matchWeek}`)
+    fetch(`${this.apiUrl}?team=${team}&player=${player}&action_type=${action_type}&match_week=${match_week}`)
     .then(response => response.json())
     .then(chartData => {
       this.chart.config.data = this.refreshChartData(chartData)

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -37,23 +37,23 @@
           </a>
         </li>
         <li class="mr-6 my-2 md:my-0">
-          <a href="#" class="block py-1 md:py-3 pl-1 align-middle text-gray-500 no-underline hover:text-gray-900 border-b-2 border-white hover:border-pink-500">
-            <i class="fas fa-tasks fa-fw mr-3"></i><span class="pb-1 md:pb-0 text-sm">Tasks</span>
+          <a href="/players" class="block py-1 md:py-3 pl-1 align-middle text-gray-500 no-underline hover:text-gray-900 border-b-2 border-white hover:border-pink-500">
+            <i class="fas fa-tasks fa-fw mr-3"></i><span class="pb-1 md:pb-0 text-sm">Fake</span>
           </a>
         </li>
         <li class="mr-6 my-2 md:my-0">
           <a href="#" class="block py-1 md:py-3 pl-1 align-middle text-gray-500 no-underline hover:text-gray-900 border-b-2 border-white hover:border-purple-500">
-            <i class="fa fa-envelope fa-fw mr-3"></i><span class="pb-1 md:pb-0 text-sm">Messages</span>
+            <i class="fa fa-envelope fa-fw mr-3"></i><span class="pb-1 md:pb-0 text-sm">Fake</span>
           </a>
         </li>
         <li class="mr-6 my-2 md:my-0">
           <a href="#" class="block py-1 md:py-3 pl-1 align-middle text-gray-500 no-underline hover:text-gray-900 border-b-2 border-white hover:border-green-500">
-            <i class="fas fa-chart-area fa-fw mr-3"></i><span class="pb-1 md:pb-0 text-sm">Analytics</span>
+            <i class="fas fa-chart-area fa-fw mr-3"></i><span class="pb-1 md:pb-0 text-sm">Fake</span>
           </a>
         </li>
         <li class="mr-6 my-2 md:my-0">
           <a href="#" class="block py-1 md:py-3 pl-1 align-middle text-gray-500 no-underline hover:text-gray-900 border-b-2 border-white hover:border-red-500">
-            <i class="fa fa-wallet fa-fw mr-3"></i><span class="pb-1 md:pb-0 text-sm">Payments</span>
+            <i class="fa fa-wallet fa-fw mr-3"></i><span class="pb-1 md:pb-0 text-sm">Fake</span>
           </a>
         </li>
       </ul>

--- a/app/views/teams/_filters.html.erb
+++ b/app/views/teams/_filters.html.erb
@@ -1,13 +1,10 @@
 <div class="flex flex-wrap" data-controller="filters" id="filters">
-  <div class="w-full md:w-1/3 px-3 mb-6 md:mb-0">
+  <div class="w-full md:w-1/4 px-3 mb-6 md:mb-0">
     <label class="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2" for="grid-state">
       Équipe
     </label>
     <div class="relative">
       <select class="block appearance-none w-full bg-white border text-gray-600 py-3 px-4 pr-8 rounded leading-tight focus:outline-none" id="grid-state" data-target="filters.team" data-action="filters#triggerUpdate">
-        <option value="">Toutes</option>
-        <option value="ACCES">ACCES</option>
-        <option>Texas</option>
       </select>
       <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
         <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
@@ -15,15 +12,25 @@
     </div>
   </div>
 
-  <div class="w-full md:w-1/3 px-3 mb-6 md:mb-0">
+  <div class="w-full md:w-1/4 px-3 mb-6 md:mb-0">
+    <label class="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2" for="grid-state">
+      Joueur
+    </label>
+    <div class="relative">
+      <select class="block appearance-none w-full bg-white border text-gray-600 py-3 px-4 pr-8 rounded leading-tight focus:outline-none" id="grid-state" data-target="filters.player" data-action="filters#triggerUpdate">
+      </select>
+      <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
+        <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
+      </div>
+    </div>
+  </div>
+
+  <div class="w-full md:w-1/4 px-3 mb-6 md:mb-0">
     <label class="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2" for="grid-state">
       Type d'action
     </label>
     <div class="relative">
       <select class="block appearance-none w-full bg-white border text-gray-600 py-3 px-4 pr-8 rounded leading-tight focus:outline-none" id="grid-state" data-target="filters.actionType" data-action="filters#triggerUpdate">
-        <option value="">Toutes</option>
-        <option value="Attaque_placee">Attaque placée</option>
-        <option>Texas</option>
       </select>
       <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
         <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
@@ -31,15 +38,12 @@
     </div>
   </div>
 
-  <div class="w-full md:w-1/3 px-3 mb-6 md:mb-0">
+  <div class="w-full md:w-1/4 px-3 mb-6 md:mb-0">
     <label class="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2" for="grid-state">
       Journée
     </label>
     <div class="relative">
       <select class="block appearance-none w-full bg-white border text-gray-600 py-3 px-4 pr-8 rounded leading-tight focus:outline-none" id="grid-state" data-target="filters.matchWeek" data-action="filters#triggerUpdate">
-        <option value="">Toutes</option>
-        <option value="J1">J1</option>
-        <option>Texas</option>
       </select>
       <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
         <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -49,7 +49,7 @@
           </div>
           <div class="p-5">
             <canvas id="pie-chart1"></canvas>
-            <div data-controller="charts--action-type-goals" data-charts--action-type-goals-canvas-id="pie-chart1">
+            <div data-controller="charts--team-goals" data-charts--team-goals-canvas-id="pie-chart1">
             </div>
           </div>
         </div>
@@ -64,7 +64,7 @@
           </div>
           <div class="p-5">
             <canvas id="pie-chart2"></canvas>
-            <div data-controller="charts--team-goals" data-charts--team-goals-canvas-id="pie-chart2">
+            <div data-controller="charts--action-type-goals" data-charts--action-type-goals-canvas-id="pie-chart2">
             </div>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     get "/goal_action_type_teams", to: "charts#goal_action_type_teams"
     get "/goal_action_type_match_weeks", to: "charts#goal_action_type_match_weeks"
     get "/teams", to: "teams#index"
+    get "/players", to: "players#index"
     get "/goals/action_types", to: "goals#action_types"
     get "/games/match_weeks", to: "games#match_weeks"
   end


### PR DESCRIPTION
Adapting view passing from 1/3 to 1/4 for filters, adding players endpoint in api
Also, adding the player param to the charts controller and js controllers too

I first thought to add a complete tab like the original app but I found it very messy. 

Instead, I added player in the list of filters. The list is *not* dynamic, which means if you first selected a team, the list of player will not be reduced to the players of your team. 

It partially closes #21 

Ex: 
![image](https://user-images.githubusercontent.com/15010293/82751221-0d3e0b00-9db6-11ea-8849-da25150ef230.png)

WDYT ? Is this enough or do we absolutely need that extra tab with exactly same datas but splitted per player ? (I don't see the point but there is maybe existing reasons?)