### PR TITLE
Dynamic refresh of filters

### DIFF
--- a/app/controllers/api/games_controller.rb
+++ b/app/controllers/api/games_controller.rb
@@ -1,8 +1,26 @@
 module Api
   class GamesController < ApplicationController
     def match_weeks
-      match_weeks = Game.all.pluck(:match_week).uniq
+      match_weeks = add_filters_to_query(Game.left_joins(:teams, :goals)).all.pluck(:match_week).uniq
       render json: match_weeks
+    end
+
+    private
+
+    def add_filters_to_query(query)
+      if (team = params[:team].presence)
+        query = query.where(teams: { acronym: team })
+      end
+
+      if (action_type = params[:action_type].presence)
+        query = query.where(goals: { action_type: action_type })
+      end
+
+      if (match_week = params[:match_week].presence)
+        query = query.where(games: { match_week: match_week })
+      end
+
+      query
     end
   end
 end

--- a/app/controllers/api/goals_controller.rb
+++ b/app/controllers/api/goals_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class GoalsController < ApplicationController
     def action_types
-      action_types = Goal.all.pluck(:action_type).uniq
+      action_types = add_filters_to_query(Goal.with_joins).all.pluck(:action_type).uniq
       render json: action_types
     end
 

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -1,8 +1,26 @@
 module Api
   class TeamsController < ApplicationController
     def index
-      teams = Team.all
+      teams = add_filters_to_query(Team.left_joins(:games, players: :goals)).all.uniq
       render json: teams
+    end
+
+    private
+
+    def add_filters_to_query(query)
+      if (team = params[:team].presence)
+        query = query.where(teams: { acronym: team })
+      end
+
+      if (action_type = params[:action_type].presence)
+        query = query.where(goals: { action_type: action_type })
+      end
+
+      if (match_week = params[:match_week].presence)
+        query = query.where(games: { match_week: match_week })
+      end
+
+      query
     end
   end
 end

--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -26,11 +26,9 @@ export default class extends Controller {
   }
 
   refreshChart() {
-    var team = document.querySelector("#filters").filters.teamTarget.value
-    var action_type = document.querySelector("#filters").filters.actionTypeTarget.value
-    var match_week = document.querySelector("#filters").filters.matchWeekTarget.value
+    var params = document.querySelector("#filters").filters.urlParams
 
-    fetch(`${this.apiUrl}?team=${team}&action_type=${action_type}&match_week=${match_week}`)
+    fetch(`${this.apiUrl}?${params}`)
     .then(response => response.json())
     .then(chartData => {
       this.chart.config.data = this.refreshChartData(chartData)

--- a/app/javascript/controllers/filters_controller.js
+++ b/app/javascript/controllers/filters_controller.js
@@ -5,47 +5,68 @@ export default class extends Controller {
 
   connect(){
     this.element[this.identifier] = this
-    this.initTeamFilter()
-    this.initActionTypeFilter()
-    this.initMatchWeekFilter()
+    this.refreshTeamFilter()
+    this.refreshActionTypeFilter()
+    this.refreshMatchWeekFilter()
   }
 
   triggerUpdate(){
     const updateCharts = new CustomEvent("updateCharts", {});
     document.dispatchEvent(updateCharts);
+    this.refreshTeamFilter();
+    this.refreshActionTypeFilter();
+    this.refreshMatchWeekFilter();
   }
 
-  initTeamFilter(){
+  refreshTeamFilter(){
     var options = `<option value="">Toutes</option>`
-    fetch(`api/teams`)
+    var active = this.teamTarget.value
+    fetch(`api/teams?${this.urlParams}`)
     .then(response => response.json())
     .then( teams => {
       teams.forEach((team) => {
-        options = options + this.optionTemplate(team.acronym, team.name);
+        if (team.acronym == active){
+          options = this.optionTemplate(team.acronym, team.name) + options;
+        }
+        else{
+          options = options + this.optionTemplate(team.acronym, team.name);
+        }
       });
       this.teamTarget.innerHTML = options;
     });
   }
 
-  initActionTypeFilter(){
+  refreshActionTypeFilter(){
     var options = `<option value="">Toutes</option>`
-    fetch(`api/goals/action_types`)
+    var active = this.actionTypeTarget.value
+    fetch(`api/goals/action_types?${this.urlParams}`)
     .then(response => response.json())
     .then( action_types => {
       action_types.forEach((action_type) => {
-        options = options + this.optionTemplate(action_type, action_type);
+        if (action_type == active){
+          options = this.optionTemplate(action_type, action_type) + options;
+        }
+        else{
+          options = options + this.optionTemplate(action_type, action_type);
+        }
       });
       this.actionTypeTarget.innerHTML = options;
     });
   }
 
-  initMatchWeekFilter(){
+  refreshMatchWeekFilter(){
     var options = `<option value="">Toutes</option>`
-    fetch(`api/games/match_weeks`)
+    var active = this.matchWeekTarget.value
+    fetch(`api/games/match_weeks?${this.urlParams}`)
     .then(response => response.json())
     .then( matchWeeks => {
       matchWeeks.forEach((matchWeek) => {
-        options = options + this.optionTemplate(matchWeek, `J${matchWeek}`);
+        if (matchWeek == active){
+          options = this.optionTemplate(matchWeek, matchWeek) + options;
+        }
+        else{
+          options = options + this.optionTemplate(matchWeek, matchWeek);
+        }
       });
       this.matchWeekTarget.innerHTML = options;
     });
@@ -56,13 +77,17 @@ export default class extends Controller {
     <option value=${value}>${text} </option>`
   }
 
-  loadListVideo(){
-    var listTarget = document.querySelector("#videos").videos.listTarget
+  get urlParams(){
     var team = this.teamTarget.value
     var action_type = this.actionTypeTarget.value
     var match_week = this.matchWeekTarget.value
+    return `team=${team}&action_type=${action_type}&match_week=${match_week}`
+  }
+
+  loadListVideo(){
+    var listTarget = document.querySelector("#videos").videos.listTarget
     var options = ""
-    fetch(`api/goals/videos?team=${team}&action_type=${action_type}&match_week=${match_week}`)
+    fetch(`api/goals/videos??${this.urlParams}`)
     .then(response => response.json())
     .then( goals => {
       goals.forEach((goal) => {

--- a/app/javascript/controllers/multi_chart_controller.js
+++ b/app/javascript/controllers/multi_chart_controller.js
@@ -31,11 +31,9 @@ export default class extends Controller {
   }
 
   refreshChart() {
-    var team = document.querySelector("#filters").filters.teamTarget.value
-    var action_type = document.querySelector("#filters").filters.actionTypeTarget.value
-    var matchWeek = document.querySelector("#filters").filters.matchWeekTarget.value
+    var params = document.querySelector("#filters").filters.urlParams
 
-    fetch(`${this.apiUrl}?team=${team}&action_type=${action_type}&match_week=${matchWeek}`)
+    fetch(`${this.apiUrl}?${params}`)
     .then(response => response.json())
     .then(chartData => {
       this.chart.config.data = this.refreshChartData(chartData)


### PR DESCRIPTION
Adding the refresh of filters on the selection of others : recalling the api using the filters as parameters to get a new list
Keeping the active filter as first option (selected one) :)

Closes #55

Example : If you selected NMF and matchweek 4, there are only two action types existing, and now, only those two would be in the action type's filter :D ✨

![image](https://user-images.githubusercontent.com/15010293/83208794-ee919880-a156-11ea-892c-049d58940628.png)
