### PR TITLE
Adding default_scope on ApplicationRecord for sorting

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,4 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  self.implicit_order_column = :created_at
 end


### PR DESCRIPTION
Having uuids on all models messes things up a bit : default sorting by id is broken, and it's better to
ensure that we sort using `created_at` fields by default.